### PR TITLE
Fix progressbar.ProgressBar initialization

### DIFF
--- a/downloader.py
+++ b/downloader.py
@@ -68,7 +68,7 @@ def change_to_highlights_folder():
 
 # Process list of bookmarks
 def process_bookmarks(bookmarks):
-    progress = progressbar.ProgressBar(max_value=len(bookmarks))
+    progress = progressbar.ProgressBar(maxval=len(bookmarks)).start()
     i = 1
     for bookmark in bookmarks:
         process_bookmark(bookmark)
@@ -159,7 +159,7 @@ for folder in folders:
 if os.path.exists("saved_state.txt"):
   os.remove("saved_state.txt")
 
-progress = progressbar.ProgressBar(max_value=len(folders))
+progress = progressbar.ProgressBar(maxval=len(folders)).start()
 print("Writing Last Saved States:")
 for folder in folders:
     i = 1


### PR DESCRIPTION
Initializing progressbar.ProgressBar with the keyword argument `max_value` fails because ProgressBar.__init__ only takes a `maxval` argument. That and a ProgressBar object needs to be further initialized before calling `update()` by first calling `start()`.

I am not sure how this broke. Looking at the [pypi page for progressbar](https://pypi.org/project/progressbar/#history), I don't see a version 2.4 to even download, which makes me suspect that the progressbar maintainers uploaded a different 2.4 version that breaks save-instapaper-highlights.

I also wanted to take this chance to express my thanks to you for creating this script. Getting my instapaper highlights exported into simple MD files was a huge boon to my productivity.